### PR TITLE
removed the dashboard link in the nav for accounts that aren't admins…

### DIFF
--- a/views/layouts/main-layout.ejs
+++ b/views/layouts/main-layout.ejs
@@ -36,8 +36,10 @@
 				<% if (!user) { %> <!-- if user jwt cookie does not exist -->
 				<li><a href="/login">Log In</a></li>
 				<li><a href="/signup">Sign Up</a></li>
-				<% } else { %>
+				<% } else if (user.role.admin || user.role.author) { %>
 					<li><a href="/dashboard">Dashboard</a></li>
+					<li><a href="/logout">Logout</a></li>
+				<% } else { %>
 					<li><a href="/logout">Logout</a></li>
 				<% } %>
 			</ul>


### PR DESCRIPTION
… or authors

Small change: I just removed the dashboard link in the nav if the user is not an author or admin. They can only become an author or admin if an admin selects "Make admin" under that users details in the users tab of the dashboard.